### PR TITLE
Leading whitespace in college chapter names broke metabase queries

### DIFF
--- a/cogs/listeners/role_events_cog.py
+++ b/cogs/listeners/role_events_cog.py
@@ -27,7 +27,7 @@ class RoleEventsListener(commands.Cog):
     @commands.Cog.listener()
     async def on_guild_role_update(self, before: discord.Role, after: discord.Role):
         if after.name.startswith("College:"):
-            orgName = after.name[len("College:") :]
+            orgName = after.name[len("College: ") :]
             SupabaseClient().addChapter(
                 roleId=after.id, orgName=orgName, type="COLLEGE"
             )


### PR DESCRIPTION
### Issue Description

This is a sql query to get average number of contributors in college chapters.
```sql
WITH chapter_membership AS (
  SELECT
    COUNT(cd.discord_id) AS count,
    cd.chapter,
    ch.type
  FROM
    (SELECT * FROM public.contributors_discord WHERE {{gender}}) cd
    LEFT JOIN chapters ch ON cd.chapter = ch.org_name
  WHERE
    cd.chapter IS NOT NULL
    AND ch.type = 'COLLEGE'
  GROUP BY
    cd.chapter,
    ch.type
)

SELECT ROUND(AVG(count)) AS "Average Member Count" FROM chapter_membership;
```


Due to leading whitespaces in chapters.org_name, this join:

``` sql
ON cd.chapter = ch.org_name
```

is failing, leading to null responses in queries.
