### PR TITLE
[Feature] Mark users as inactive instead of deleting them while syncing discord to database via the bot

### DIFF
--- a/cogs/serverManagement.py
+++ b/cogs/serverManagement.py
@@ -79,7 +79,7 @@ class ServerManagement(commands.Cog):
         currentMembers = [member.id for member in guild.members]
         membersWhoLeft = list(set(recordedMembers) - set(currentMembers))
         print(f"{len(membersWhoLeft)} members left")
-        SupabaseClient().deleteContributorDiscord(membersWhoLeft)
+        SupabaseClient().invalidateContributorDiscord(membersWhoLeft)
         print("Updated Contributors")
 
     @tasks.loop(minutes=30)

--- a/cogs/serverManagement.py
+++ b/cogs/serverManagement.py
@@ -22,7 +22,7 @@ class ServerManagement(commands.Cog):
         return ctx.author.id in authorised_users
 
     @commands.command(aliaes=["initiate"])
-    async def getServerData(self, ctx):
+    async def updateServerData(self, ctx):
         # add all chapters
         chapterRoles = []
         guild = self.bot.get_guild(serverConfig.SERVER)

--- a/cogs/serverManagement.py
+++ b/cogs/serverManagement.py
@@ -52,7 +52,7 @@ class ServerManagement(commands.Cog):
 
         print("added chapters")
 
-        contributorsGithub = SupabaseClient().read_all_active("contributors_registration")
+        contributorsGithub = SupabaseClient().read_all("contributors_registration")
         contributorsDiscord = SupabaseClient().read_all_active("contributors_discord")
 
         ## Give contributor role

--- a/cogs/serverManagement.py
+++ b/cogs/serverManagement.py
@@ -15,12 +15,10 @@ class ServerManagement(commands.Cog):
 
     def validUser(self, ctx):
         authorised_users = [
-            1042682119035568178,
             1120262151676895274,
             1107555866422562926,
-            1107555866422562926,
-            599878601143222282,
-        ]  # bhavya, devaraj, navaneeth, venkatesh, sukhpreet
+            1059343450312544266,
+        ]  # devaraj, venkatesh, karn
         return ctx.author.id in authorised_users
 
     @commands.command(aliaes=["initiate"])
@@ -54,8 +52,8 @@ class ServerManagement(commands.Cog):
 
         print("added chapters")
 
-        contributorsGithub = SupabaseClient().read_all("contributors_registration")
-        contributorsDiscord = SupabaseClient().read_all("contributors_discord")
+        contributorsGithub = SupabaseClient().read_all_active("contributors_registration")
+        contributorsDiscord = SupabaseClient().read_all_active("contributors_discord")
 
         ## Give contributor role
         contributorIds = [

--- a/helpers/supabaseClient.py
+++ b/helpers/supabaseClient.py
@@ -63,6 +63,10 @@ class SupabaseClient:
     def read_all(self, table):
         data = self.client.table(table).select("*").execute()
         return data.data
+    
+    def read_all_active(self, table):
+        data = self.client.table(table).select("*").eq('is_active', 'true').execute()
+        return data.data
 
     def update(self, table, update, query_key, query_value):
         data = (
@@ -137,6 +141,7 @@ class SupabaseClient:
                     "chapter": chapters[0] if chapters else None,
                     "gender": gender,
                     "joined_at": contributor.joined_at.isoformat(),
+                    "is_active": 'true'
                 }
             )
 
@@ -149,3 +154,8 @@ class SupabaseClient:
         table = "contributors_discord"
         for id in contributorDiscordIds:
             self.client.table(table).delete().eq("discord_id", id).execute()
+
+    def invalidateContributorDiscord(self, contributorDiscordIds):
+        table = "contributors_discord"
+        for id in contributorDiscordIds:
+            self.client.table(table).update({ 'is_active': 'false' }).eq('discord_id', id).execute()

--- a/main.py
+++ b/main.py
@@ -112,7 +112,7 @@ class RegistrationModal(discord.ui.Modal):
         super().__init__(title=title, timeout=timeout, custom_id=custom_id)
 
     async def post_data(self, data):
-        url = "https://kcavhjwafgtoqkqbbqrd.supabase.co/rest/v1/contributor_names"
+        url = os.getenv("SUPABASE_URL")
         headers = {
             "apikey": f"{os.getenv('SUPABASE_KEY')}",
             "Authorization": f"Bearer {os.getenv('SUPABASE_KEY')}",


### PR DESCRIPTION
## Description

Discord doesn't send a [gateway event](https://discord.com/developers/docs/topics/gateway-events#receive-events) when users leave the server of their own volition, while it *does* send a gateway event when they join.

Therefore we currently have to sync the data of all members who are currently on the server (obtained from [github APIs](https://discordpy.readthedocs.io/en/stable/api.html#discord.Guild.members)) with the data of the members we've recorded when they joined and mark all those who've left in the intervening period as `inactive` to get accurate metrics on the community.